### PR TITLE
add scope to api

### DIFF
--- a/web/router.ex
+++ b/web/router.ex
@@ -14,9 +14,9 @@ defmodule MovieWagerApi.Router do
     plug :fetch_session
   end
 
-  scope "/", MovieWagerApi do
+  scope "/api/v1", MovieWagerApi do
     pipe_through :api
 
-    resources "/movie-round", MovieRoundController, only: [:index]
+    resources "/movie-rounds", MovieRoundController, only: [:index]
   end
 end


### PR DESCRIPTION
Added a different scope for the api, otherwise our front-end will have conflicts if we have routes by the same name as our endpoints.