### PR TITLE
add create endpoint to movie round controller

### DIFF
--- a/test/controllers/movie_round_controller_test.exs
+++ b/test/controllers/movie_round_controller_test.exs
@@ -15,4 +15,24 @@ defmodule MovieWagerApi.MovieRoundControllerTest do
       |> json_response(200)
     end
   end
+
+  describe "POST create" do
+    test "it inserts records with proper params", %{conn: conn} do
+      movie_params = params_for(:movie_round, title: "movie title")
+      conn
+      |> post(movie_round_path(conn, :create), json_for(:movie_round, movie_params))
+      |> json_response(201)
+
+      new_movie_round = MovieWagerApi.Repo.get_by(MovieWagerApi.MovieRound, title: "movie title")
+      assert new_movie_round
+    end
+
+    test "it returns 401 with invalid credentials", %{conn: conn} do
+      movie_params = %{}
+
+      resp = post(conn, movie_round_path(conn, :create), json_for(:movie_round, movie_params))
+
+      assert resp.status == 422
+    end
+  end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -25,6 +25,7 @@ defmodule MovieWagerApi.ConnCase do
       import Ecto.Changeset
       import Ecto.Query
       import MovieWagerApi.Factory
+      import MovieWagerApi.TestHelpers
 
       import MovieWagerApi.Router.Helpers
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,44 @@
+defmodule MovieWagerApi.TestHelpers do
+  def json_for(type, attributes) do
+    attributes = normalize_json_attributes(attributes)
+
+    %{
+      "data" => %{
+        "type" =>  Atom.to_string(type) |> String.replace("_", "-"),
+        "attributes" => attributes,
+      },
+      "format" => "json-api"
+    }
+  end
+
+  def json_for(type, attributes, %{} = relationships) do
+    json = json_for(type, attributes)
+    put_in json["data"]["relationships"], relationships
+  end
+
+  def json_for(type, attributes, id) do
+    json = json_for(type, attributes)
+    put_in json["data"]["id"], id
+  end
+
+  defp normalize_json_attributes(attributes) do
+    attributes = attributes
+      |> Map.delete(:__meta__)
+      |> Map.delete(:__struct__)
+
+    Enum.reduce attributes, %{}, fn({key, value}, result) ->
+      case normalize_json_attribute(key, value) do
+        {key, value} -> Map.put(result, key, value)
+        nil -> result
+      end
+    end
+  end
+
+  defp normalize_json_attribute(key, %Ecto.DateTime{} = value) do
+    {key, Ecto.DateTime.to_iso8601(value)}
+  end
+
+  defp normalize_json_attribute(_key, %Ecto.Association.NotLoaded{} = _value), do: nil
+
+  defp normalize_json_attribute(key, value), do: {key, value}
+end

--- a/web/controllers/movie_round_controller.ex
+++ b/web/controllers/movie_round_controller.ex
@@ -10,4 +10,19 @@ defmodule MovieWagerApi.MovieRoundController do
 
     json(conn, serialized_rounds)
   end
+
+  def create(conn, stuff = %{"data" =>  %{"attributes" => movie_round_params}}) do
+    changeset = MovieRound.changeset(%MovieRound{}, movie_round_params)
+    case Repo.insert(changeset) do
+      {:ok, movie_round} ->
+        serialized_movie_round = JaSerializer.format(MovieRoundSerializer, movie_round, conn)
+
+        conn
+        |> put_status(:created)
+        |> json(serialized_movie_round)
+
+      {:error, changeset} ->
+        send_resp(conn, :unprocessable_entity, "")
+    end
+  end
 end

--- a/web/models/movie_round.ex
+++ b/web/models/movie_round.ex
@@ -17,6 +17,6 @@ defmodule MovieWagerApi.MovieRound do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:code, :start_date, :end_date, :box_office_amount, :title])
-    |> validate_required([:code, :start_date, :end_date, :box_office_amount, :title])
+    |> validate_required([:code, :start_date, :end_date, :title])
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -12,11 +12,12 @@ defmodule MovieWagerApi.Router do
   pipeline :api do
     plug :accepts, ["json-api"]
     plug :fetch_session
+    plug JaSerializer.Deserializer
   end
 
   scope "/api/v1", MovieWagerApi do
     pipe_through :api
 
-    resources "/movie-rounds", MovieRoundController, only: [:index]
+    resources "/movie-rounds", MovieRoundController, only: [:index, :create]
   end
 end


### PR DESCRIPTION
This adds a create endpoint for the movie rounds. Eventually, this should be behind some sort of authentication, but we can just use a regular post endpoint for now.