### PR TITLE
add update endpoint for movie_round controller

### DIFF
--- a/test/controllers/movie_round_controller_test.exs
+++ b/test/controllers/movie_round_controller_test.exs
@@ -49,4 +49,18 @@ defmodule MovieWagerApi.MovieRoundControllerTest do
       assert resp.status == 422
     end
   end
+
+  describe "PATCH update" do
+    test "it updates and returns a valid movie_round", %{conn: conn} do
+      movie_round = insert(:movie_round, box_office_amount: nil)
+
+      json = json_for(:wager, %{box_office_amount: 1000})
+
+      resp = conn
+        |> put(movie_round_path(conn, :update, movie_round.id), json)
+        |> json_response(200)
+
+      assert resp["data"]["attributes"]["box-office-amount"] == 1000
+    end
+  end
 end

--- a/test/services/scorer_test.exs
+++ b/test/services/scorer_test.exs
@@ -1,0 +1,44 @@
+defmodule MovieWagerApi.ScorerServiceTest do
+  use ExUnit.Case
+  use MovieWagerApi.ServiceCase
+
+  alias MovieWagerApi.{Wager, Scorer}
+
+  describe "sort_wagers" do
+    test "it properly sorts wagers" do
+      movie_round = insert(:movie_round, box_office_amount: 1000)
+      [_wager_one, wager_two, wager_three] = place_three_wagers(movie_round)
+      sorted_wagers = Scorer.sort_wagers(movie_round.id, movie_round.box_office_amount)
+
+      assert List.first(sorted_wagers).amount == wager_three.amount
+      assert List.last(sorted_wagers).amount == wager_two.amount
+    end
+  end
+
+  describe "finalize_results" do
+    test "it returns nil with no amount" do
+      movie_round = insert(:movie_round)
+
+      refute Scorer.finalize_results(movie_round)
+    end
+
+    test "it populates place for each wager" do
+      movie_round = insert(:movie_round, box_office_amount: 1000)
+      [wager_one, wager_two, wager_three] = place_three_wagers(movie_round)
+
+      Scorer.finalize_results(movie_round)
+
+      assert Repo.get(Wager, wager_three.id).place == 1
+      assert Repo.get(Wager, wager_one.id).place == 2
+      assert Repo.get(Wager, wager_two.id).place == 3
+    end
+  end
+
+  defp place_three_wagers(movie_round) do
+    wager_one = insert(:wager, movie_round: movie_round, amount: 890)
+    wager_two = insert(:wager, movie_round: movie_round, amount: 700)
+    wager_three = insert(:wager, movie_round: movie_round, amount: 1100)
+
+    [wager_one, wager_two, wager_three]
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,7 +6,7 @@ defmodule MovieWagerApi.Factory do
       code: sequence(:code, &"Monkey #{&1}: Die Harder"),
       start_date: Ecto.Date.from_erl({2016,1,1}),
       end_date: Ecto.Date.from_erl({2016,1,3}),
-      box_office_amount: 10000000,
+      box_office_amount: nil,
       title: "Funky Monkey Bunch"
     }
   end

--- a/test/support/service_case.ex
+++ b/test/support/service_case.ex
@@ -1,0 +1,20 @@
+defmodule MovieWagerApi.ServiceCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias MovieWagerApi.Repo
+      import MovieWagerApi.Factory
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MovieWagerApi.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(MovieWagerApi.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+end

--- a/web/controllers/movie_round_controller.ex
+++ b/web/controllers/movie_round_controller.ex
@@ -5,30 +5,43 @@ defmodule MovieWagerApi.MovieRoundController do
 
   def index(conn, _params) do
     movie_rounds = Repo.all(MovieRound)
-
-    serialized_rounds = JaSerializer.format(MovieRoundSerializer, movie_rounds, conn)
-
-    json(conn, serialized_rounds)
+    serialized_movie_round(conn, movie_rounds, 200)
   end
 
   def show(conn, %{"id" => id}) do
-    round = Repo.get(MovieRound, id)
-    serialized_round = JaSerializer.format(MovieRoundSerializer, round, conn)
-    json(conn, serialized_round)
+    movie_round = Repo.get(MovieRound, id)
+    serialized_movie_round(conn, movie_round, 200)
   end
 
   def create(conn, %{"data" =>  %{"attributes" => movie_round_params}}) do
     changeset = MovieRound.changeset(%MovieRound{}, movie_round_params)
     case Repo.insert(changeset) do
       {:ok, movie_round} ->
-        serialized_movie_round = JaSerializer.format(MovieRoundSerializer, movie_round, conn)
-
-        conn
-        |> put_status(:created)
-        |> json(serialized_movie_round)
+        serialized_movie_round(conn, movie_round, :created)
 
       {:error, _changeset} ->
         send_resp(conn, :unprocessable_entity, "")
     end
+  end
+
+  def update(conn, %{"id" => id, "data" => %{"attributes" => params}}) do
+    movie_round = Repo.get!(MovieRound, id)
+    changeset = MovieRound.changeset(movie_round, params)
+
+    case Repo.update(changeset) do
+      {:ok, movie_round} ->
+        serialized_movie_round(conn, movie_round, 200)
+      {:error, _changeset} ->
+        send_resp(conn, :unprocessable_entity, "")
+    end
+  end
+
+  defp serialized_movie_round(conn, movie_round, status) do
+    serialized_movie_round = MovieRoundSerializer
+      |> JaSerializer.format(movie_round, conn)
+
+    conn
+    |> put_status(status)
+    |> json(serialized_movie_round)
   end
 end

--- a/web/controllers/movie_round_controller.ex
+++ b/web/controllers/movie_round_controller.ex
@@ -1,7 +1,7 @@
 defmodule MovieWagerApi.MovieRoundController do
   use MovieWagerApi.Web, :controller
 
-  alias MovieWagerApi.{Repo, MovieRound, MovieRoundSerializer}
+  alias MovieWagerApi.{MovieRound, MovieRoundSerializer, Repo, Scorer}
 
   def index(conn, _params) do
     movie_rounds = Repo.all(MovieRound)
@@ -30,6 +30,7 @@ defmodule MovieWagerApi.MovieRoundController do
 
     case Repo.update(changeset) do
       {:ok, movie_round} ->
+        Scorer.finalize_results(movie_round)
         serialized_movie_round(conn, movie_round, 200)
       {:error, _changeset} ->
         send_resp(conn, :unprocessable_entity, "")

--- a/web/router.ex
+++ b/web/router.ex
@@ -19,7 +19,7 @@ defmodule MovieWagerApi.Router do
   scope "/api/v1", MovieWagerApi do
     pipe_through :api
 
-    resources "/movie-rounds", MovieRoundController, only: [:index, :create, :show]
+    resources "/movie-rounds", MovieRoundController, only: [:index, :create, :show, :update]
     resources "/users", UserController, only: [:show]
     resources "/twitter-auth", TwitterController, only: [:create]
     get "/session", SessionController, :show

--- a/web/services/scorer.ex
+++ b/web/services/scorer.ex
@@ -1,0 +1,27 @@
+defmodule MovieWagerApi.Scorer do
+  alias MovieWagerApi.{Repo, Wager}
+
+  import Ecto.Query
+
+  def finalize_results(%{box_office_amount: nil}), do: nil
+
+  def finalize_results(movie_round) do
+    sort_wagers(movie_round.id, movie_round.box_office_amount)
+    |> Enum.with_index(1)
+    |> Enum.each(fn {wager, idx} ->
+      changeset = Wager.changeset(wager, %{place: idx})
+
+      Repo.update(changeset)
+    end)
+  end
+
+  def sort_wagers(movie_round_id, box_office_amount) do
+    wagers = Wager
+      |> where(movie_round_id: ^movie_round_id)
+      |> Repo.all
+
+    Enum.sort(wagers, fn(current, next) ->
+      abs(current.amount - box_office_amount) < abs(next.amount - box_office_amount)
+    end)
+  end
+end


### PR DESCRIPTION
## What's in this PR?

This PR checks wagers for a given round and determines the winners if a `box_office_amount` is present.  This happens through a service, making it reusable if we want to extract it later, but right now it is triggered through the `update` action on the round controller.