### PR TITLE
allow wagers to be filtered by round

### DIFF
--- a/test/controllers/wager_controller_test.exs
+++ b/test/controllers/wager_controller_test.exs
@@ -21,6 +21,20 @@ defmodule MovieWagerApi.WagerControllerTest do
       assert length(resp["data"]) == 1
       assert ids_from_response(resp) == [wager.id]
     end
+
+    test "it returns wagers for a given round", %{conn: conn} do
+      movie_round = insert(:movie_round)
+
+      [wager_one, wager_two] = insert_pair(:wager, movie_round: movie_round)
+      insert_pair(:wager)
+
+      resp = conn
+        |> get(wager_path(conn, :index, %{movie_round_id: movie_round.id}))
+        |> json_response(200)
+
+      assert length(resp["data"]) == 2
+      assert ids_from_response(resp) == [wager_one.id, wager_two.id]
+    end
   end
 
   describe "POST create" do

--- a/web/controllers/wager_controller.ex
+++ b/web/controllers/wager_controller.ex
@@ -30,6 +30,14 @@ defmodule MovieWagerApi.WagerController do
     serialized_wager(conn, wagers, 200)
   end
 
+  def index(conn, %{"movie_round_id" => movie_round_id}) do
+    wagers = Wager
+      |> where(movie_round_id: ^movie_round_id)
+      |> Repo.all
+
+    serialized_wager(conn, wagers, 200)
+  end
+
   def update(conn, %{"id" => id, "data" => %{"attributes" => wager_params}}) do
     wager = Repo.get!(Wager, id)
 


### PR DESCRIPTION
## What's in this PR

This PR adds another index endpoint for wagers, to allow us to filter it by round only (i.e. returning all bets for all users)